### PR TITLE
Format Python code with Black Code Formatter

### DIFF
--- a/custom_components/places/sensor.py
+++ b/custom_components/places/sensor.py
@@ -1000,9 +1000,6 @@ class Places(Entity):
                                 self._place_neighbourhood.strip() + " Neighborhood"
                             )
 
-
-
-
                 else:
                     formatted_place_array.append(self._place_name.strip())
                 if self._city != "-":


### PR DESCRIPTION
There appear to be some python formatting errors in 9269e7d44b66bb3b2c48ae985c1ca04401ebd4cf. This pull request
uses the [Black Code Formatter](https://github.com/psf/black) to fix these issues.