### PR TITLE
Format Python code with Black Code Formatter

### DIFF
--- a/custom_components/places/sensor.py
+++ b/custom_components/places/sensor.py
@@ -906,7 +906,7 @@ class Places(Entity):
             elif "city_district" in osm_decoded["address"]:
                 city = osm_decoded["address"]["city_district"]
             if city.startswith("City of"):
-                city = city[8:]+" City"
+                city = city[8:] + " City"
 
             if "city_district" in osm_decoded["address"]:
                 postal_town = osm_decoded["address"]["city_district"]
@@ -988,8 +988,8 @@ class Places(Entity):
                             .strip()
                         )
                     elif (
-                          self._place_category != "-"
-                          and self._place_category.lower() != "highway"
+                        self._place_category != "-"
+                        and self._place_category.lower() != "highway"
                     ):
                         formatted_place_array.append(
                             self._place_category.title().strip()


### PR DESCRIPTION
There appear to be some python formatting errors in 63251a1f092c1fdd9b12decbb25d98e344022254. This pull request
uses the [Black Code Formatter](https://github.com/psf/black) to fix these issues.