### PR TITLE
Format Python code with Black Code Formatter

### DIFF
--- a/custom_components/places/sensor.py
+++ b/custom_components/places/sensor.py
@@ -1001,7 +1001,10 @@ class Places(Entity):
                             formatted_place_array.append(
                                 self._street_number.strip() + " " + self._street.strip()
                             )
-                    if self._place_type.lower() == "house" and self._place_neighbourhood != "-":
+                    if (
+                        self._place_type.lower() == "house"
+                        and self._place_neighbourhood != "-"
+                    ):
                         formatted_place_array.append(
                             self._place_neighbourhood.strip() + " Neighborhood"
                         )


### PR DESCRIPTION
There appear to be some python formatting errors in 1e14b608aa2a81da7ac53223076aa95db0d32955. This pull request
uses the [Black Code Formatter](https://github.com/psf/black) to fix these issues.