### PR TITLE
Format Python code with Black Code Formatter

### DIFF
--- a/custom_components/places/sensor.py
+++ b/custom_components/places/sensor.py
@@ -1143,7 +1143,12 @@ class Places(Entity):
                 self._osm_dict = osm_decoded
             current_time = "%02d:%02d" % (now.hour, now.minute)
 
-            if previous_state.lower().strip() != new_state.lower().strip() and previous_state.replace(' ','').lower().strip() != new_state.lower().strip() and previous_state.lower().strip() != devicetracker_zone.lower().strip():
+            if (
+                previous_state.lower().strip() != new_state.lower().strip()
+                and previous_state.replace(" ", "").lower().strip()
+                != new_state.lower().strip()
+                and previous_state.lower().strip() != devicetracker_zone.lower().strip()
+            ):
 
                 if self._extended_attr:
                     osm_details_dict = {}


### PR DESCRIPTION
There appear to be some python formatting errors in f6efc35238881524b69f8c1551953dd76dc0b669. This pull request
uses the [Black Code Formatter](https://github.com/psf/black) to fix these issues.