### PR TITLE
Format Python code with Black Code Formatter

### DIFF
--- a/custom_components/places/sensor.py
+++ b/custom_components/places/sensor.py
@@ -1005,9 +1005,7 @@ class Places(Entity):
                         self._place_type.lower() == "house"
                         and self._place_neighbourhood != "-"
                     ):
-                        formatted_place_array.append(
-                            self._place_neighbourhood.strip()
-                        )
+                        formatted_place_array.append(self._place_neighbourhood.strip())
 
                 else:
                     formatted_place_array.append(self._place_name.strip())


### PR DESCRIPTION
There appear to be some python formatting errors in 529c1bbd292df408a51a2a5c04d270afe50a1562. This pull request
uses the [Black Code Formatter](https://github.com/psf/black) to fix these issues.