### PR TITLE
Format Python code with Black Code Formatter

### DIFF
--- a/custom_components/places/sensor.py
+++ b/custom_components/places/sensor.py
@@ -709,7 +709,7 @@ class Places(Entity):
                     "("
                     + self._name
                     + ") Meters traveled since last update: "
-                    + str(round(distance_traveled,1))
+                    + str(round(distance_traveled, 1))
                 )
             else:
                 _LOGGER.error(
@@ -749,7 +749,7 @@ class Places(Entity):
                 "("
                 + self._name
                 + ") Skipping update because location changed "
-                + str(round(distance_traveled,1))
+                + str(round(distance_traveled, 1))
                 + " < 10m  ("
                 + str(self._updateskipped)
                 + ")"


### PR DESCRIPTION
There appear to be some python formatting errors in 4ddbea68be5b59265cf703c6eea3b4ecfb2fca86. This pull request
uses the [Black Code Formatter](https://github.com/psf/black) to fix these issues.