### PR TITLE
Format Python code with Black Code Formatter

### DIFF
--- a/custom_components/places/sensor.py
+++ b/custom_components/places/sensor.py
@@ -709,7 +709,7 @@ class Places(Entity):
                     "("
                     + self._name
                     + ") Meters traveled since last update: "
-                    + str(round(distance_traveled,1))
+                    + str(round(distance_traveled, 1))
                 )
             else:
                 _LOGGER.error(
@@ -749,7 +749,7 @@ class Places(Entity):
                 "("
                 + self._name
                 + ") Skipping update because location changed "
-                + str(round(distance_traveled,1))
+                + str(round(distance_traveled, 1))
                 + " < 10m  ("
                 + str(self._updateskipped)
                 + ")"
@@ -761,7 +761,11 @@ class Places(Entity):
             proceed_with_update = True
 
         if proceed_with_update and devicetracker_zone:
-            _LOGGER.debug("(" + self._name + ") Meets criteria, proceeding with OpenStreetMap query")
+            _LOGGER.debug(
+                "("
+                + self._name
+                + ") Meets criteria, proceeding with OpenStreetMap query"
+            )
             self._devicetracker_zone = devicetracker_zone
             _LOGGER.info(
                 "("
@@ -1281,7 +1285,9 @@ class Places(Entity):
                 _LOGGER.debug("(" + self._name + ") EventData update complete")
             else:
                 _LOGGER.debug(
-                    "(" + self._name + ") No entity update needed, Previous State = New State"
+                    "("
+                    + self._name
+                    + ") No entity update needed, Previous State = New State"
                 )
 
     def _reset_attributes(self):


### PR DESCRIPTION
There appear to be some python formatting errors in 2971e9b9b53b409c1a00c1a341c90319f4771be1. This pull request
uses the [Black Code Formatter](https://github.com/psf/black) to fix these issues.