### PR TITLE
Format Python code with Black Code Formatter

### DIFF
--- a/custom_components/places/sensor.py
+++ b/custom_components/places/sensor.py
@@ -507,8 +507,7 @@ class Places(Entity):
     def do_update(self, reason):
         """Get the latest data and updates the states."""
 
-        _LOGGER.info(
-            "(" + self._name + ") Starting Update...")
+        _LOGGER.info("(" + self._name + ") Starting Update...")
         previous_state = self.state
         distance_traveled = 0
         devicetracker_zone = None
@@ -556,28 +555,52 @@ class Places(Entity):
             previous_location = old_latitude + "," + old_longitude
             home_location = home_latitude + "," + home_longitude
             prev_last_place_name = self._last_place_name
-            _LOGGER.debug("(" + self._name + ") Previous last_place_name: " + str(self._last_place_name))
+            _LOGGER.debug(
+                "("
+                + self._name
+                + ") Previous last_place_name: "
+                + str(self._last_place_name)
+            )
 
             if (
                 "stationary" in self._devicetracker_zone.lower()
                 or self._devicetracker_zone.lower() == "away"
                 or self._devicetracker_zone.lower() == "not_home"
             ):
-                 #Not in a Zone
+                # Not in a Zone
                 if self._place_name is not None and self._place_name != "-":
-                    #If place name is set
+                    # If place name is set
                     last_place_name = self._place_name
-                    _LOGGER.debug("(" + self._name + ") Previous Place Name is set: " + last_place_name + ", updating")
+                    _LOGGER.debug(
+                        "("
+                        + self._name
+                        + ") Previous Place Name is set: "
+                        + last_place_name
+                        + ", updating"
+                    )
                 else:
                     # If blank, keep previous last place name
                     last_place_name = self._last_place_name
-                    _LOGGER.debug("(" + self._name + ") Previous Place Name is None or -, keeping prior")
+                    _LOGGER.debug(
+                        "("
+                        + self._name
+                        + ") Previous Place Name is None or -, keeping prior"
+                    )
             else:
                 # In a Zone
                 last_place_name = self._devicetracker_zone_name
-                _LOGGER.debug("(" + self._name + ") Previous Place is Zone: " + last_place_name + ", updating")
+                _LOGGER.debug(
+                    "("
+                    + self._name
+                    + ") Previous Place is Zone: "
+                    + last_place_name
+                    + ", updating"
+                )
             _LOGGER.debug(
-                "(" + self._name + ") Last Place Name (Initial): " + str(last_place_name)
+                "("
+                + self._name
+                + ") Last Place Name (Initial): "
+                + str(last_place_name)
             )
 
             maplink_apple = (
@@ -918,11 +941,26 @@ class Places(Entity):
             self._osm_type = osm_type
             if initial_update == True:
                 last_place_name = self._last_place_name
-                _LOGGER.debug("(" + self._name + ") Runnining initial update after load, using prior last_place_name")
-            elif last_place_name == place_name or last_place_name == devicetracker_zone_name:
+                _LOGGER.debug(
+                    "("
+                    + self._name
+                    + ") Runnining initial update after load, using prior last_place_name"
+                )
+            elif (
+                last_place_name == place_name
+                or last_place_name == devicetracker_zone_name
+            ):
                 # If current place name/zone are the same as previous, keep older last place name
                 last_place_name = self._last_place_name
-                _LOGGER.debug("(" + self._name + ") Initial last_place_name is same as new: place_name=" + place_name + " or devicetracker_zone_name=" + devicetracker_zone_name+ ", keeping previous last_place_name")
+                _LOGGER.debug(
+                    "("
+                    + self._name
+                    + ") Initial last_place_name is same as new: place_name="
+                    + place_name
+                    + " or devicetracker_zone_name="
+                    + devicetracker_zone_name
+                    + ", keeping previous last_place_name"
+                )
             else:
                 _LOGGER.debug("(" + self._name + ") Keeping initial last_place_name")
             self._last_place_name = last_place_name
@@ -1245,7 +1283,10 @@ class Places(Entity):
                     event_data[ATTR_PLACE_NAME] = place_name
                 if current_time is not None:
                     event_data[ATTR_MTIME] = current_time
-                if last_place_name is not None and last_place_name != prev_last_place_name:
+                if (
+                    last_place_name is not None
+                    and last_place_name != prev_last_place_name
+                ):
                     event_data[ATTR_LAST_PLACE_NAME] = last_place_name
                 if distance_from_home is not None:
                     event_data["distance_from_home"] = distance_from_home
@@ -1285,16 +1326,17 @@ class Places(Entity):
                         event_data[ATTR_WIKIDATA_DICT] = wikidata_dict
                 # _LOGGER.debug( "(" + self._name + ") Event Data: " + event_data )
                 self._hass.bus.fire(DEFAULT_NAME + "_state_update", event_data)
-                _LOGGER.debug("(" + self._name + ") EventData updated: " + str(event_data))
+                _LOGGER.debug(
+                    "(" + self._name + ") EventData updated: " + str(event_data)
+                )
             else:
                 _LOGGER.debug(
                     "("
                     + self._name
                     + ") No entity update needed, Previous State = New State"
                 )
-        _LOGGER.info(
-            "(" + self._name + ") End of Update")
-        
+        _LOGGER.info("(" + self._name + ") End of Update")
+
     def _reset_attributes(self):
         """Resets attributes."""
         self._street = None
@@ -1310,7 +1352,7 @@ class Places(Entity):
         self._place_type = None
         self._place_name = None
         self._mtime = datetime.now()
-        #self._last_place_name = None
+        # self._last_place_name = None
         self._osm_id = None
         self._osm_type = None
         self._wikidata_id = None


### PR DESCRIPTION
There appear to be some python formatting errors in 486b4d6b501d473d648deb0a93bdfcba5fb01f6e. This pull request
uses the [Black Code Formatter](https://github.com/psf/black) to fix these issues.