### PR TITLE
Format Python code with Black Code Formatter

### DIFF
--- a/custom_components/places/sensor.py
+++ b/custom_components/places/sensor.py
@@ -964,7 +964,9 @@ class Places(Entity):
             else:
                 _LOGGER.debug("(" + self._name + ") Keeping initial last_place_name")
             self._last_place_name = last_place_name
-            _LOGGER.debug("(" + self._name + ") Last Place Name (Final): " + str(last_place_name))
+            _LOGGER.debug(
+                "(" + self._name + ") Last Place Name (Final): " + str(last_place_name)
+            )
             isDriving = False
 
             display_options = []


### PR DESCRIPTION
There appear to be some python formatting errors in 8b03bbe48a006e105061cf377ae0dac19d25981e. This pull request
uses the [Black Code Formatter](https://github.com/psf/black) to fix these issues.