### PR TITLE
Format Python code with Black Code Formatter

### DIFF
--- a/custom_components/places/sensor.py
+++ b/custom_components/places/sensor.py
@@ -1050,7 +1050,9 @@ class Places(Entity):
                 )
             elif "formatted_place" in display_options:
                 new_state = self._formatted_place
-                _LOGGER.info("(" + self._name + ") New State using formatted_place: " + new_state)
+                _LOGGER.info(
+                    "(" + self._name + ") New State using formatted_place: " + new_state
+                )
             elif (
                 self._devicetracker_zone.lower() == "not_home"
                 or "stationary" in self._devicetracker_zone.lower()


### PR DESCRIPTION
There appear to be some python formatting errors in e93383b3f05f40a74c08e5520ff7e88d0c241070. This pull request
uses the [Black Code Formatter](https://github.com/psf/black) to fix these issues.