### PR TITLE
Format Python code with isort & Black Code Formatter

### DIFF
--- a/custom_components/places/sensor.py
+++ b/custom_components/places/sensor.py
@@ -1071,7 +1071,9 @@ class Places(Entity):
                 _LOGGER.debug(
                     "("
                     + self._name
-                    + ") Building State from Display Options: "+ self._options)
+                    + ") Building State from Display Options: "
+                    + self._options
+                )
 
                 user_display = []
 


### PR DESCRIPTION
There appear to be some python formatting errors in 6367dd546cb03472adde655b0522f9beda867628. This pull request
uses the [Black Code Formatter](https://github.com/psf/black) and [isort](https://pycqa.github.io/isort) to fix these issues.