### PR TITLE
Format Python code with isort & Black Code Formatter

### DIFF
--- a/custom_components/places/sensor.py
+++ b/custom_components/places/sensor.py
@@ -1058,7 +1058,9 @@ class Places(Entity):
                 )
             elif "formatted_place" in display_options:
                 new_state = self._formatted_place
-                _LOGGER.info("(" + self._name + ") New State using formatted_place: " + new_state)
+                _LOGGER.info(
+                    "(" + self._name + ") New State using formatted_place: " + new_state
+                )
             elif (
                 self._devicetracker_zone.lower() == "not_home"
                 or "stationary" in self._devicetracker_zone.lower()


### PR DESCRIPTION
There appear to be some python formatting errors in d10b6b4a3759f44f1b9863c5ecf88a2912e0ac4e. This pull request
uses the [Black Code Formatter](https://github.com/psf/black) and [isort](https://pycqa.github.io/isort) to fix these issues.