### PR TITLE
Format Python code with isort & Black Code Formatter

### DIFF
--- a/custom_components/places/sensor.py
+++ b/custom_components/places/sensor.py
@@ -1068,10 +1068,12 @@ class Places(Entity):
 
                 # Options:  "formatted_place, zone, zone_name, place, street_number, street, city, county, state, postal_code, country, formatted_address"
 
-                _LOGGER.debug("("
+                _LOGGER.debug(
+                    "("
                     + self._name
                     + ") Building State from Display Options: "
-                    + self._options)
+                    + self._options
+                )
 
                 user_display = []
 


### PR DESCRIPTION
There appear to be some python formatting errors in c9ee512d84fb4c2abfbd6bb9c95189b808d0d502. This pull request
uses the [Black Code Formatter](https://github.com/psf/black) and [isort](https://pycqa.github.io/isort) to fix these issues.