### PR TITLE
Format Python code with isort & Black Code Formatter

### DIFF
--- a/custom_components/places/sensor.py
+++ b/custom_components/places/sensor.py
@@ -1051,9 +1051,11 @@ class Places(Entity):
 
             if "error_message" in osm_decoded:
                 new_state = osm_decoded["error_message"]
-                _LOGGER.info("("
+                _LOGGER.info(
+                    "("
                     + self._name
-                    + ") An error occurred contacting the web service for OpenStreetMap")
+                    + ") An error occurred contacting the web service for OpenStreetMap"
+                )
             elif "formatted_place" in display_options:
                 new_state = self._formatted_place
                 _LOGGER.info(


### PR DESCRIPTION
There appear to be some python formatting errors in 1a14f510483c26beee8be62fa8cc64fe8802d615. This pull request
uses the [Black Code Formatter](https://github.com/psf/black) and [isort](https://pycqa.github.io/isort) to fix these issues.