### PR TITLE
Format Python code with isort & Black Code Formatter

### DIFF
--- a/custom_components/places/sensor.py
+++ b/custom_components/places/sensor.py
@@ -151,20 +151,28 @@ To enable detailed logging for this component, add the following to your configu
 
 """
 
-import logging, json, requests
-from datetime import datetime, timedelta
-from requests import get
-from math import radians, cos, sin, asin, sqrt
+import json
+import logging
+from datetime import datetime
+from datetime import timedelta
+from math import asin
+from math import cos
+from math import radians
+from math import sin
+from math import sqrt
 
-import voluptuous as vol
 import homeassistant.helpers.config_validation as cv
-
+import requests
+import voluptuous as vol
 from homeassistant.components.sensor import PLATFORM_SCHEMA
+from homeassistant.const import CONF_API_KEY
+from homeassistant.const import CONF_NAME
+from homeassistant.const import CONF_SCAN_INTERVAL
+from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.event import track_state_change
 from homeassistant.util import Throttle
 from homeassistant.util.location import distance
-from homeassistant.helpers.entity import Entity
-from homeassistant.const import CONF_API_KEY, CONF_NAME, CONF_SCAN_INTERVAL
+from requests import get
 
 _LOGGER = logging.getLogger(__name__)
 


### PR DESCRIPTION
There appear to be some python formatting errors in 6689ca37ee81667331f13a5a1202649f782906da. This pull request
uses the [Black Code Formatter](https://github.com/psf/black) and [isort](https://pycqa.github.io/isort) to fix these issues.