### PR TITLE
Format Python code with isort & Black Code Formatter

### DIFF
--- a/custom_components/places/__init__.py
+++ b/custom_components/places/__init__.py
@@ -1,9 +1,9 @@
-
 """GitHub Custom Component."""
 import asyncio
 import logging
 
-from homeassistant import config_entries, core
+from homeassistant import config_entries
+from homeassistant import core
 
 from .const import DOMAIN
 


### PR DESCRIPTION
There appear to be some python formatting errors in 8f179042167c17bf518a8d99149d970f759dbf3f. This pull request
uses the [Black Code Formatter](https://github.com/psf/black) and [isort](https://pycqa.github.io/isort) to fix these issues.