### PR TITLE
Format Python code with isort & Black Code Formatter

### DIFF
--- a/custom_components/places/const.py
+++ b/custom_components/places/const.py
@@ -66,4 +66,3 @@ ATTR_OSM_DICT = "osm_dict"
 ATTR_OSM_DETAILS_DICT = "osm_details_dict"
 ATTR_WIKIDATA_DICT = "wikidata_dict"
 ATTR_LAST_PLACE_NAME = "last_place_name"
-

--- a/custom_components/places/sensor.py
+++ b/custom_components/places/sensor.py
@@ -163,7 +163,6 @@ from math import sqrt
 
 import homeassistant.helpers.config_validation as cv
 import voluptuous as vol
-from .const import *
 from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.const import CONF_API_KEY
 from homeassistant.const import CONF_NAME
@@ -173,6 +172,8 @@ from homeassistant.helpers.event import track_state_change
 from homeassistant.util import Throttle
 from homeassistant.util.location import distance
 from requests import get
+
+from .const import *
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -191,6 +192,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
         vol.Optional(CONF_EXTENDED_ATTR, default=DEFAULT_EXTENDED_ATTR): cv.boolean,
     }
 )
+
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Setup the sensor platform."""


### PR DESCRIPTION
There appear to be some python formatting errors in ce12cfa05b62dbd0095323a32568337d6bbfcd70. This pull request
uses the [Black Code Formatter](https://github.com/psf/black) and [isort](https://pycqa.github.io/isort) to fix these issues.