### PR TITLE
Format Python code with isort & Black Code Formatter

### DIFF
--- a/custom_components/places/sensor.py
+++ b/custom_components/places/sensor.py
@@ -153,13 +153,20 @@ To enable detailed logging for this component, add the following to your configu
 
 import json
 import logging
-from datetime import datetime, timedelta
-from math import asin, cos, radians, sin, sqrt
+from datetime import datetime
+from datetime import timedelta
+from math import asin
+from math import cos
+from math import radians
+from math import sin
+from math import sqrt
 
 import homeassistant.helpers.config_validation as cv
 import voluptuous as vol
 from homeassistant.components.sensor import PLATFORM_SCHEMA
-from homeassistant.const import CONF_API_KEY, CONF_NAME, CONF_SCAN_INTERVAL
+from homeassistant.const import CONF_API_KEY
+from homeassistant.const import CONF_NAME
+from homeassistant.const import CONF_SCAN_INTERVAL
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.event import track_state_change
 from homeassistant.util import Throttle


### PR DESCRIPTION
There appear to be some python formatting errors in b911ecb485e3116ef7e4328dc6a2d29643f9cc4e. This pull request
uses the [Black Code Formatter](https://github.com/psf/black) and [isort](https://pycqa.github.io/isort) to fix these issues.