### PR TITLE
Format Python code with isort & Black Code Formatter

### DIFF
--- a/custom_components/places/config_flow.py
+++ b/custom_components/places/config_flow.py
@@ -4,8 +4,8 @@ import logging
 from typing import Any
 
 import voluptuous as vol
-
-from homeassistant import config_entries, exceptions
+from homeassistant import config_entries
+from homeassistant import exceptions
 from homeassistant.core import HomeAssistant
 
 from .const import DOMAIN  # pylint:disable=unused-import


### PR DESCRIPTION
There appear to be some python formatting errors in 9c44e8c13aaebc0c052d546a0ba7f3faebadb365. This pull request
uses the [Black Code Formatter](https://github.com/psf/black) and [isort](https://pycqa.github.io/isort) to fix these issues.