### PR TITLE
Format Python code with isort & Black Code Formatter

### DIFF
--- a/custom_components/places/__init__.py
+++ b/custom_components/places/__init__.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 
-#from . import hub
+# from . import hub
 from .const import DOMAIN
 
 # List of platforms to support. There should be a matching .py file for each,


### PR DESCRIPTION
There appear to be some python formatting errors in cebbf35eb07ab3054a5c2eaf20837822e57e3042. This pull request
uses the [Black Code Formatter](https://github.com/psf/black) and [isort](https://pycqa.github.io/isort) to fix these issues.