### PR TITLE
Format Python code with isort & Black Code Formatter

### DIFF
--- a/custom_components/places/config_flow.py
+++ b/custom_components/places/config_flow.py
@@ -3,14 +3,15 @@ from __future__ import annotations
 import logging
 from typing import Any
 
+import homeassistant.helpers.config_validation as cv
 import voluptuous as vol
 from homeassistant import config_entries
 from homeassistant import exceptions
-from homeassistant.core import HomeAssistant
-import homeassistant.helpers.config_validation as cv
 from homeassistant.const import CONF_API_KEY
 from homeassistant.const import CONF_NAME
 from homeassistant.const import CONF_SCAN_INTERVAL
+from homeassistant.core import HomeAssistant
+
 from .const import CONF_DEVICETRACKER_ID
 from .const import CONF_EXTENDED_ATTR
 from .const import CONF_HOME_ZONE

--- a/custom_components/places/sensor.py
+++ b/custom_components/places/sensor.py
@@ -230,7 +230,6 @@ from .const import DEFAULT_MAP_ZOOM
 from .const import DEFAULT_NAME
 from .const import DEFAULT_OPTION
 
-
 THROTTLE_INTERVAL = timedelta(seconds=600)
 TRACKABLE_DOMAINS = ["device_tracker"]
 _LOGGER = logging.getLogger(__name__)


### PR DESCRIPTION
There appear to be some python formatting errors in 1e7e9f591ab9468def2c4a389a95fa31fbeb854f. This pull request
uses the [Black Code Formatter](https://github.com/psf/black) and [isort](https://pycqa.github.io/isort) to fix these issues.