### PR TITLE
Format Python code with isort & Black Code Formatter

### DIFF
--- a/custom_components/places/config_flow.py
+++ b/custom_components/places/config_flow.py
@@ -51,7 +51,7 @@ DATA_SCHEMA = vol.Schema(
         vol.Optional(CONF_MAP_PROVIDER, default=DEFAULT_MAP_PROVIDER): str,
         vol.Optional(CONF_MAP_ZOOM, default=DEFAULT_MAP_ZOOM): str,
         vol.Optional(CONF_LANGUAGE, default=DEFAULT_LANGUAGE): str,
-        #vol.Optional(CONF_SCAN_INTERVAL, default=SCAN_INTERVAL): cv.time_period,
+        # vol.Optional(CONF_SCAN_INTERVAL, default=SCAN_INTERVAL): cv.time_period,
         vol.Optional(CONF_EXTENDED_ATTR, default=DEFAULT_EXTENDED_ATTR): bool,
     }
 )


### PR DESCRIPTION
There appear to be some python formatting errors in 2e3c17fe77454f232409d0ef11c8cf50f34860e6. This pull request
uses the [Black Code Formatter](https://github.com/psf/black) and [isort](https://pycqa.github.io/isort) to fix these issues.