### PR TITLE
Format Python code with isort & Black Code Formatter

### DIFF
--- a/custom_components/places/__init__.py
+++ b/custom_components/places/__init__.py
@@ -1,11 +1,14 @@
 import asyncio
 import logging
-from homeassistant import config_entries, core
+
+from homeassistant import config_entries
+from homeassistant import core
+
 from .const import DOMAIN
 
-#from __future__ import annotations
-#from homeassistant.config_entries import ConfigEntry
-#from homeassistant.core import HomeAssistant
+# from __future__ import annotations
+# from homeassistant.config_entries import ConfigEntry
+# from homeassistant.core import HomeAssistant
 # from . import hub
 
 
@@ -16,7 +19,9 @@ _LOGGER = logging.getLogger(__name__)
 PLATFORMS: list[str] = ["sensor"]
 
 
-async def async_setup_entry(hass: core.HomeAssistant, entry: config_entries.ConfigEntry) -> bool:
+async def async_setup_entry(
+    hass: core.HomeAssistant, entry: config_entries.ConfigEntry
+) -> bool:
     """Set up from a config entry."""
     # Store an instance of the "connecting" class that does the work of speaking
     # with your actual devices.
@@ -31,7 +36,9 @@ async def async_setup_entry(hass: core.HomeAssistant, entry: config_entries.Conf
     return True
 
 
-async def async_unload_entry(hass: core.HomeAssistant, entry: config_entries.ConfigEntry) -> bool:
+async def async_unload_entry(
+    hass: core.HomeAssistant, entry: config_entries.ConfigEntry
+) -> bool:
     """Unload a config entry."""
     # This is called when an entry/configured device is to be removed. The class
     # needs to unload itself, and remove callbacks. See the classes for further

--- a/custom_components/places/config_flow.py
+++ b/custom_components/places/config_flow.py
@@ -5,13 +5,15 @@ from typing import Any
 
 import homeassistant.helpers.config_validation as cv
 import voluptuous as vol
-#from homeassistant import config_entries
-#from homeassistant import exceptions
-from homeassistant import config_entries, core, exceptions
+
+# from homeassistant import config_entries
+# from homeassistant import exceptions
+from homeassistant import config_entries
+from homeassistant import core
+from homeassistant import exceptions
 from homeassistant.const import CONF_API_KEY
 from homeassistant.const import CONF_NAME
 from homeassistant.const import CONF_SCAN_INTERVAL
-#from homeassistant.core import HomeAssistant
 
 from .const import CONF_DEVICETRACKER_ID
 from .const import CONF_EXTENDED_ATTR
@@ -31,10 +33,13 @@ from .const import DEFAULT_OPTION
 from .const import DOMAIN  # pylint:disable=unused-import
 from .const import SCAN_INTERVAL
 
+# from homeassistant.core import HomeAssistant
+
+
 # from .hub import Hub
 
 _LOGGER = logging.getLogger(__name__)
-MAP_PROVIDER_OPTIONS = ["apple","google","osm"]
+MAP_PROVIDER_OPTIONS = ["apple", "google", "osm"]
 
 # Note the input displayed to the user will be translated. See the
 # translations/<lang>.json file and strings.json. See here for further information:
@@ -50,8 +55,12 @@ DATA_SCHEMA = vol.Schema(
         vol.Optional(CONF_API_KEY): str,
         vol.Optional(CONF_OPTIONS, default=DEFAULT_OPTION): str,
         vol.Optional(CONF_HOME_ZONE, default=DEFAULT_HOME_ZONE): str,
-        vol.Optional(CONF_MAP_PROVIDER, default=DEFAULT_MAP_PROVIDER): vol.In(MAP_PROVIDER_OPTIONS),
-        vol.Optional(CONF_MAP_ZOOM, default=int(DEFAULT_MAP_ZOOM)): vol.All(vol.Coerce(int), vol.Range(min=1, max=20)),
+        vol.Optional(CONF_MAP_PROVIDER, default=DEFAULT_MAP_PROVIDER): vol.In(
+            MAP_PROVIDER_OPTIONS
+        ),
+        vol.Optional(CONF_MAP_ZOOM, default=int(DEFAULT_MAP_ZOOM)): vol.All(
+            vol.Coerce(int), vol.Range(min=1, max=20)
+        ),
         vol.Optional(CONF_LANGUAGE): str,
         # vol.Optional(CONF_SCAN_INTERVAL, default=SCAN_INTERVAL): cv.time_period,
         vol.Optional(CONF_EXTENDED_ATTR, default=DEFAULT_EXTENDED_ATTR): bool,

--- a/custom_components/places/sensor.py
+++ b/custom_components/places/sensor.py
@@ -165,7 +165,8 @@ from typing import Optional
 
 import homeassistant.helpers.config_validation as cv
 import voluptuous as vol
-from homeassistant import config_entries, core
+from homeassistant import config_entries
+from homeassistant import core
 from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.const import CONF_API_KEY
 from homeassistant.const import CONF_NAME
@@ -235,8 +236,8 @@ from .const import DEFAULT_MAP_PROVIDER
 from .const import DEFAULT_MAP_ZOOM
 from .const import DEFAULT_NAME
 from .const import DEFAULT_OPTION
-from .const import SCAN_INTERVAL
 from .const import DOMAIN
+from .const import SCAN_INTERVAL
 
 THROTTLE_INTERVAL = timedelta(seconds=600)
 TRACKABLE_DOMAINS = ["device_tracker"]
@@ -266,24 +267,24 @@ async def async_setup_entry(
     async_add_entities,
 ) -> None:
     """Setup the sensor platform."""
-    #_LOGGER.debug("config_entry: " + str(config_entry))
+    # _LOGGER.debug("config_entry: " + str(config_entry))
     config = hass.data[DOMAIN][config_entry.entry_id]
     unique_id = config_entry.entry_id
     name = config.get(CONF_NAME)
-    #_LOGGER.debug("config type: " + str(type(config)))
+    # _LOGGER.debug("config type: " + str(type(config)))
     _LOGGER.debug("config: " + str(config))
 
-    #name = config.get(CONF_NAME)
-    #api_key = config.get(CONF_API_KEY)
-    #devicetracker_id = config.get(CONF_DEVICETRACKER_ID)
-    #options = config.get(CONF_OPTIONS)
-    #home_zone = config.get(CONF_HOME_ZONE)
-    #map_provider = config.get(CONF_MAP_PROVIDER)
-    #map_zoom = config.get(CONF_MAP_ZOOM)
-    #language = config.get(CONF_LANGUAGE)
-    #extended_attr = config.get(CONF_EXTENDED_ATTR)
+    # name = config.get(CONF_NAME)
+    # api_key = config.get(CONF_API_KEY)
+    # devicetracker_id = config.get(CONF_DEVICETRACKER_ID)
+    # options = config.get(CONF_OPTIONS)
+    # home_zone = config.get(CONF_HOME_ZONE)
+    # map_provider = config.get(CONF_MAP_PROVIDER)
+    # map_zoom = config.get(CONF_MAP_ZOOM)
+    # language = config.get(CONF_LANGUAGE)
+    # extended_attr = config.get(CONF_EXTENDED_ATTR)
 
-    #async_add_entities(
+    # async_add_entities(
     #    [
     #        Places(
     #            hass,
@@ -298,14 +299,14 @@ async def async_setup_entry(
     #            extended_attr,
     #        )
     #    ]
-    #)
+    # )
     async_add_entities([Places(hass, config, name, unique_id)], update_before_add=True)
 
 
 class Places(Entity):
     """Representation of a Places Sensor."""
 
-    #def __init__(
+    # def __init__(
     #    self,
     #    hass,
     #    devicetracker_id,
@@ -317,25 +318,23 @@ class Places(Entity):
     #    map_zoom,
     #    language,
     #    extended_attr,
-    #):
-    def __init__(
-        self, hass, config, name, unique_id
-    ):
+    # ):
+    def __init__(self, hass, config, name, unique_id):
         """Initialize the sensor."""
-        #_LOGGER.debug("config type: " + str(type(config)))
-        #_LOGGER.debug("self type: " + str(type(self)))
+        # _LOGGER.debug("config type: " + str(type(config)))
+        # _LOGGER.debug("self type: " + str(type(self)))
         _LOGGER.debug("New places sensor: " + str(name))
         _LOGGER.debug("(" + str(name) + ") unique_id: " + str(unique_id))
         _LOGGER.debug("(" + str(name) + ") config: " + str(config))
-        #name = config.get(CONF_NAME)
+        # name = config.get(CONF_NAME)
         devicetracker_id = config.get(CONF_DEVICETRACKER_ID)
         api_key = config.setdefault(CONF_API_KEY, DEFAULT_KEY)
-        options = config.setdefault(CONF_OPTIONS,DEFAULT_OPTION)
-        home_zone = config.setdefault(CONF_HOME_ZONE,DEFAULT_HOME_ZONE)
-        map_provider = config.setdefault(CONF_MAP_PROVIDER,DEFAULT_MAP_PROVIDER)
-        map_zoom = config.setdefault(CONF_MAP_ZOOM,DEFAULT_MAP_ZOOM)
-        language = config.setdefault(CONF_LANGUAGE,DEFAULT_LANGUAGE)
-        extended_attr = config.setdefault(CONF_EXTENDED_ATTR,DEFAULT_EXTENDED_ATTR)
+        options = config.setdefault(CONF_OPTIONS, DEFAULT_OPTION)
+        home_zone = config.setdefault(CONF_HOME_ZONE, DEFAULT_HOME_ZONE)
+        map_provider = config.setdefault(CONF_MAP_PROVIDER, DEFAULT_MAP_PROVIDER)
+        map_zoom = config.setdefault(CONF_MAP_ZOOM, DEFAULT_MAP_ZOOM)
+        language = config.setdefault(CONF_LANGUAGE, DEFAULT_LANGUAGE)
+        extended_attr = config.setdefault(CONF_EXTENDED_ATTR, DEFAULT_EXTENDED_ATTR)
         self._hass = hass
         self._name = name
         self._unique_id = unique_id
@@ -400,19 +399,19 @@ class Places(Entity):
         self._osm_dict = None
         self._osm_details_dict = None
         self._wikidata_dict = None
-        
-        #_LOGGER.debug("config type: " + str(type(config)))
-        #_LOGGER.debug("config: " + str(config))
-        #_LOGGER.debug("self type: " + str(type(self)))
-        #_LOGGER.debug("self: " + str(self))
+
+        # _LOGGER.debug("config type: " + str(type(config)))
+        # _LOGGER.debug("config: " + str(config))
+        # _LOGGER.debug("self type: " + str(type(self)))
+        # _LOGGER.debug("self: " + str(self))
 
         # Check if devicetracker_id was specified correctly
         _LOGGER.info(
             "(" + self._name + ") DeviceTracker Entity ID: " + self._devicetracker_id
         )
 
-        #if devicetracker_id.split(".", 1)[0] in TRACKABLE_DOMAINS:
-        #self._devicetracker_id = devicetracker_id
+        # if devicetracker_id.split(".", 1)[0] in TRACKABLE_DOMAINS:
+        # self._devicetracker_id = devicetracker_id
         async_track_state_change(
             hass,
             self._devicetracker_id,


### PR DESCRIPTION
There appear to be some python formatting errors in cd6065fb9f0e236607a2178a345cf2d07b462a23. This pull request
uses the [Black Code Formatter](https://github.com/psf/black) and [isort](https://pycqa.github.io/isort) to fix these issues.