### PR TITLE
Format Python code with isort & Black Code Formatter

### DIFF
--- a/custom_components/places/sensor.py
+++ b/custom_components/places/sensor.py
@@ -300,7 +300,9 @@ class Places(Entity):
         home_latitude = str(hass.states.get(self._home_zone).attributes.get("latitude"))
         if not self.is_float(home_latitude):
             home_latitude = None
-        home_longitude = str(hass.states.get(self._home_zone).attributes.get("longitude"))
+        home_longitude = str(
+            hass.states.get(self._home_zone).attributes.get("longitude")
+        )
         if not self.is_float(home_longitude):
             home_longitude = None
         self._entity_picture = (


### PR DESCRIPTION
There appear to be some python formatting errors in 692badfa271f8ed324cda5dc4a103f79ed169387. This pull request
uses the [Black Code Formatter](https://github.com/psf/black) and [isort](https://pycqa.github.io/isort) to fix these issues.