### PR TITLE
Format Python code with isort & Black Code Formatter

### DIFF
--- a/custom_components/places/sensor.py
+++ b/custom_components/places/sensor.py
@@ -540,10 +540,16 @@ class Places(Entity):
             "(" + self._name + ") DeviceTracker Entity ID: " + self._devicetracker_id
         )
         _LOGGER.debug(
-            "(" + self._name + ") DeviceTracker Attribute: " + str(hasattr(self, "_devicetracker_id"))
+            "("
+            + self._name
+            + ") DeviceTracker Attribute: "
+            + str(hasattr(self, "_devicetracker_id"))
         )
         _LOGGER.debug(
-            "(" + self._name + ") DeviceTracker Entity: " + str(self._hass.states.get(self._devicetracker_id))
+            "("
+            + self._name
+            + ") DeviceTracker Entity: "
+            + str(self._hass.states.get(self._devicetracker_id))
         )
 
         if (


### PR DESCRIPTION
There appear to be some python formatting errors in c91c230fda068af9178c65776e7879b8e6dced37. This pull request
uses the [Black Code Formatter](https://github.com/psf/black) and [isort](https://pycqa.github.io/isort) to fix these issues.