### PR TITLE
Format Python code with isort & Black Code Formatter

### DIFF
--- a/custom_components/places/sensor.py
+++ b/custom_components/places/sensor.py
@@ -29,13 +29,11 @@ from homeassistant import config_entries
 from homeassistant import core
 from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.const import CONF_API_KEY
+from homeassistant.const import CONF_ENTITY_ID
+from homeassistant.const import CONF_FRIENDLY_NAME
 from homeassistant.const import CONF_NAME
 from homeassistant.const import CONF_SCAN_INTERVAL
 from homeassistant.const import Platform
-from homeassistant.const import (
-    CONF_ENTITY_ID,
-    CONF_FRIENDLY_NAME,
-)
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.event import async_track_state_change
 from homeassistant.util import Throttle
@@ -483,19 +481,28 @@ class Places(Entity):
         _LOGGER.info("(" + self._name + ") Calling update due to " + str(reason))
         if hasattr(self, "entity_id") and self.entity_id is not None:
             _LOGGER.debug("(" + self._name + ") Entity ID: " + str(self.entity_id))
-            #_LOGGER.debug(
+            # _LOGGER.debug(
             #    "("
             #    + self._name
             #    + ") Entity Data: "
             #    + str(self._hass.states.get(str(self.entity_id)))
-            #)
-            if self._name != self._hass.states.get(str(self.entity_id)).attributes.get("friendly_name"):
-                _LOGGER.debug("("
+            # )
+            if self._name != self._hass.states.get(str(self.entity_id)).attributes.get(
+                "friendly_name"
+            ):
+                _LOGGER.debug(
+                    "("
                     + self._name
                     + ") Updating Name to: "
-                    + str(self._hass.states.get(str(self.entity_id)).attributes.get("friendly_name"))
-                ) 
-                self._name = self._hass.states.get(str(self.entity_id)).attributes.get("friendly_name")
+                    + str(
+                        self._hass.states.get(str(self.entity_id)).attributes.get(
+                            "friendly_name"
+                        )
+                    )
+                )
+                self._name = self._hass.states.get(str(self.entity_id)).attributes.get(
+                    "friendly_name"
+                )
         _LOGGER.info(
             "(" + self._name + ") Check if update req'd: " + str(self._devicetracker_id)
         )


### PR DESCRIPTION
There appear to be some python formatting errors in 73e665ff8a735f37745c0b82b6d4293f64b1765f. This pull request
uses the [Black Code Formatter](https://github.com/psf/black) and [isort](https://pycqa.github.io/isort) to fix these issues.