### PR TITLE
Format Python code with isort & Black Code Formatter

### DIFF
--- a/custom_components/places/sensor.py
+++ b/custom_components/places/sensor.py
@@ -821,7 +821,7 @@ class Places(Entity):
                 + str(self._longitude)
             )
             _LOGGER.debug("(" + self._name + ") OSM URL: " + str(osm_url))
-            osm_response = await self._hass.async_add_executor_job(get,osm_url)
+            osm_response = await self._hass.async_add_executor_job(get, osm_url)
             osm_json_input = osm_response.text
             _LOGGER.debug("(" + self._name + ") OSM Response: " + osm_json_input)
             osm_decoded = json.loads(osm_json_input)


### PR DESCRIPTION
There appear to be some python formatting errors in 5b9f0b581d54cf7d5cb35c2c3c1d4fc1099c2f01. This pull request
uses the [Black Code Formatter](https://github.com/psf/black) and [isort](https://pycqa.github.io/isort) to fix these issues.