### PR TITLE
Format Python code with isort & Black Code Formatter

### DIFF
--- a/custom_components/places/sensor.py
+++ b/custom_components/places/sensor.py
@@ -409,8 +409,8 @@ class Places(Entity):
                 + self._name
                 + ") [Async Update] Running Update - Devicetracker is set"
             )
-            await self._hass.async_add_executor_job(self.do_update,"Scan Interval")
-            #self.do_update("Scan Interval")
+            await self._hass.async_add_executor_job(self.do_update, "Scan Interval")
+            # self.do_update("Scan Interval")
         else:
             _LOGGER.debug(
                 "("


### PR DESCRIPTION
There appear to be some python formatting errors in 5601f592415221e7e15753cb137efc3048b7ccec. This pull request
uses the [Black Code Formatter](https://github.com/psf/black) and [isort](https://pycqa.github.io/isort) to fix these issues.