### PR TITLE
Format Python code with isort & Black Code Formatter

### DIFF
--- a/custom_components/places/config_flow.py
+++ b/custom_components/places/config_flow.py
@@ -90,7 +90,7 @@ async def validate_input(hass: core.HomeAssistant, data: dict) -> dict[str, Any]
     """
     # Validate the data can be used to set up a connection.
     _LOGGER.debug("[config_flow validate_input] data: " + str(data))
-    #if hasattr(data,CONF_MAP_ZOOM) and data[CONF_MAP_ZOOM] is not None:
+    # if hasattr(data,CONF_MAP_ZOOM) and data[CONF_MAP_ZOOM] is not None:
     #    data[CONF_MAP_ZOOM] = int(data[CONF_MAP_ZOOM])
     # This is a simple example to show an error in the UI for a short hostname
     # The exceptions are defined at the end of this file, and are used in the
@@ -144,7 +144,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         # `validate_input` above.
         errors = {}
         if user_input is not None:
-            
+
             try:
                 info = await validate_input(self.hass, user_input)
                 _LOGGER.debug("[config_flow] user_input: " + str(user_input))


### PR DESCRIPTION
There appear to be some python formatting errors in cdf11904b7296188f6c7bd67789030e6f759bfed. This pull request
uses the [Black Code Formatter](https://github.com/psf/black) and [isort](https://pycqa.github.io/isort) to fix these issues.