### PR TITLE
Format Python code with isort & Black Code Formatter

### DIFF
--- a/custom_components/places/sensor.py
+++ b/custom_components/places/sensor.py
@@ -34,12 +34,13 @@ from homeassistant.const import CONF_NAME
 from homeassistant.const import CONF_SCAN_INTERVAL
 from homeassistant.const import EVENT_HOMEASSISTANT_START
 from homeassistant.helpers.entity import Entity
-from homeassistant.helpers.event import async_track_state_change
-from homeassistant.util import Throttle
-from homeassistant.util.location import distance
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.event import async_call_later
-from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
+from homeassistant.helpers.event import async_track_state_change
+from homeassistant.helpers.typing import ConfigType
+from homeassistant.helpers.typing import DiscoveryInfoType
+from homeassistant.util import Throttle
+from homeassistant.util.location import distance
 from requests import get
 
 from .const import ATTR_CITY


### PR DESCRIPTION
There appear to be some python formatting errors in fc9786978ae0959e3ed65df726bad8456cda37a4. This pull request
uses the [Black Code Formatter](https://github.com/psf/black) and [isort](https://pycqa.github.io/isort) to fix these issues.