### PR TITLE
Format Python code with isort & Black Code Formatter

### DIFF
--- a/custom_components/places/config_flow.py
+++ b/custom_components/places/config_flow.py
@@ -140,12 +140,14 @@ class PlacesConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     async def async_step_import(self, import_config=None) -> FlowResult:
         """Import a config entry from configuration.yaml."""
-        _LOGGER.debug("[async_step_import] initial import_config: " + str(import_config))
+        _LOGGER.debug(
+            "[async_step_import] initial import_config: " + str(import_config)
+        )
 
         data = {}
         try:
             for item in import_config:
-                if item not in ["platform","scan_interval"]:
+                if item not in ["platform", "scan_interval"]:
                     data[item] = import_config.get(item)
         except Exception as err:
             _LOGGER.warning("[async_step_import] Import error: " + str(err))


### PR DESCRIPTION
There appear to be some python formatting errors in 5c8d3e715d05264289798b78a30dd50a70d696ec. This pull request
uses the [Black Code Formatter](https://github.com/psf/black) and [isort](https://pycqa.github.io/isort) to fix these issues.