### PR TITLE
Format Python code with isort & Black Code Formatter

### DIFF
--- a/custom_components/places/sensor.py
+++ b/custom_components/places/sensor.py
@@ -573,7 +573,11 @@ class Places(Entity):
                     + ") Updated Config Name: "
                     + str(self._config[CONF_NAME])
                 )
-                self._hass.config_entries.async_update_entry(self._config_entry, data=self._config, options=self._config_entry.options)
+                self._hass.config_entries.async_update_entry(
+                    self._config_entry,
+                    data=self._config,
+                    options=self._config_entry.options,
+                )
                 _LOGGER.debug(
                     "("
                     + self._name


### PR DESCRIPTION
There appear to be some python formatting errors in 95839a3d96774b90eb6d6f70d0398e8e570830f2. This pull request
uses the [Black Code Formatter](https://github.com/psf/black) and [isort](https://pycqa.github.io/isort) to fix these issues.