### PR TITLE
Format Python code with isort & Black Code Formatter

### DIFF
--- a/custom_components/places/__init__.py
+++ b/custom_components/places/__init__.py
@@ -18,7 +18,7 @@ async def async_setup_entry(
 ) -> bool:
     """Set up from a config entry."""
 
-    #_LOGGER.debug("[init async_setup_entry] entry: " + str(entry.data))
+    # _LOGGER.debug("[init async_setup_entry] entry: " + str(entry.data))
     hass.data.setdefault(DOMAIN, {})
     hass_data = dict(entry.data)
     hass.data[DOMAIN][entry.entry_id] = hass_data


### PR DESCRIPTION
There appear to be some python formatting errors in 750af577ac415aa64fd1c5b7d5faa47a56638e12. This pull request
uses the [Black Code Formatter](https://github.com/psf/black) and [isort](https://pycqa.github.io/isort) to fix these issues.