### PR TITLE
Format Python code with isort & Black Code Formatter

### DIFF
--- a/custom_components/places/config_flow.py
+++ b/custom_components/places/config_flow.py
@@ -173,10 +173,10 @@ class PlacesOptionsFlowHandler(config_entries.OptionsFlow):
             step_id="init",
             data_schema=vol.Schema(
                 {
-                    #vol.Required(CONF_NAME, default=self.config_entry.data[CONF_NAME]): str,
+                    # vol.Required(CONF_NAME, default=self.config_entry.data[CONF_NAME]): str,
                     vol.Required(
                         CONF_DEVICETRACKER_ID,
-                        default=self.config_entry.data[CONF_DEVICETRACKER_ID]
+                        default=self.config_entry.data[CONF_DEVICETRACKER_ID],
                     ): selector.EntitySelector(
                         selector.SingleEntitySelectorConfig(domain=TRACKING_DOMAIN)
                     ),
@@ -220,7 +220,8 @@ class PlacesOptionsFlowHandler(config_entries.OptionsFlow):
                         CONF_LANGUAGE, default=self.config_entry.data[CONF_LANGUAGE]
                     ): str,
                     vol.Optional(
-                        CONF_EXTENDED_ATTR, default=self.config_entry.data[CONF_EXTENDED_ATTR]
+                        CONF_EXTENDED_ATTR,
+                        default=self.config_entry.data[CONF_EXTENDED_ATTR],
                     ): selector.BooleanSelector(selector.BooleanSelectorConfig()),
                 }
             ),

--- a/custom_components/places/sensor.py
+++ b/custom_components/places/sensor.py
@@ -860,13 +860,10 @@ class Places(Entity):
                 + str(self._latitude)
                 + "&lon="
                 + str(self._longitude)
-                + "&accept-language=" + str(self._language)
+                + "&accept-language="
+                + str(self._language)
                 + "&addressdetails=1&namedetails=1&zoom=18&limit=1"
-                + (
-                    "&email=" + str(self._api_key)
-                    if self._api_key is not None
-                    else ""
-                )
+                + ("&email=" + str(self._api_key) if self._api_key is not None else "")
             )
 
             osm_decoded = {}
@@ -1246,8 +1243,8 @@ class Places(Entity):
                                 if self._api_key is not None
                                 else ""
                             )
-                            + "&accept-language=" + str(self._language)
-
+                            + "&accept-language="
+                            + str(self._language)
                         )
 
                         _LOGGER.info(


### PR DESCRIPTION
There appear to be some python formatting errors in 4cce63aefc7685076bb0de7a69e99f78e50ee90a. This pull request
uses the [Black Code Formatter](https://github.com/psf/black) and [isort](https://pycqa.github.io/isort) to fix these issues.