### PR TITLE
Format Python code with isort & Black Code Formatter

### DIFF
--- a/custom_components/places/config_flow.py
+++ b/custom_components/places/config_flow.py
@@ -122,7 +122,10 @@ class PlacesConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         # If there is no user input or there were errors, show the form again, including any errors that were found with the input.
         return self.async_show_form(
-            step_id="user", data_schema=DATA_SCHEMA, errors=errors, description_placeholders={
+            step_id="user",
+            data_schema=DATA_SCHEMA,
+            errors=errors,
+            description_placeholders={
                 "component_config_url": COMPONENT_CONFIG_URL,
             },
         )
@@ -227,7 +230,8 @@ class PlacesOptionsFlowHandler(config_entries.OptionsFlow):
                         default=self.config_entry.data[CONF_EXTENDED_ATTR],
                     ): selector.BooleanSelector(selector.BooleanSelectorConfig()),
                 }
-            ), description_placeholders={
+            ),
+            description_placeholders={
                 "component_config_url": COMPONENT_CONFIG_URL,
             },
         )


### PR DESCRIPTION
There appear to be some python formatting errors in c16b5a3004c129e235658b21e03e6fa0d57f1de9. This pull request
uses the [Black Code Formatter](https://github.com/psf/black) and [isort](https://pycqa.github.io/isort) to fix these issues.