### PR TITLE
Format Python code with isort & Black Code Formatter

### DIFF
--- a/custom_components/places/config_flow.py
+++ b/custom_components/places/config_flow.py
@@ -220,7 +220,9 @@ class PlacesOptionsFlowHandler(config_entries.OptionsFlow):
                         CONF_MAP_ZOOM, default=self.config_entry.data[CONF_MAP_ZOOM]
                     ): selector.NumberSelector(
                         selector.NumberSelectorConfig(
-                            min=MAP_ZOOM_MIN, max=MAP_ZOOM_MAX, mode=selector.NumberSelectorMode.BOX
+                            min=MAP_ZOOM_MIN,
+                            max=MAP_ZOOM_MAX,
+                            mode=selector.NumberSelectorMode.BOX,
                         )
                     ),
                     vol.Optional(


### PR DESCRIPTION
There appear to be some python formatting errors in 597368695b1bbc116dc6263a1d4ed7e912a6f88a. This pull request
uses the [Black Code Formatter](https://github.com/psf/black) and [isort](https://pycqa.github.io/isort) to fix these issues.