### PR TITLE
Format Python code with isort & Black Code Formatter

### DIFF
--- a/custom_components/places/config_flow.py
+++ b/custom_components/places/config_flow.py
@@ -183,15 +183,29 @@ class PlacesOptionsFlowHandler(config_entries.OptionsFlow):
                     # vol.Required(CONF_NAME, default=self.config_entry.data[CONF_NAME] if CONF_NAME in self.config_entry.data else None)): str,
                     vol.Required(
                         CONF_DEVICETRACKER_ID,
-                        default=(self.config_entry.data[CONF_DEVICETRACKER_ID] if CONF_DEVICETRACKER_ID in self.config_entry.data else None)
+                        default=(
+                            self.config_entry.data[CONF_DEVICETRACKER_ID]
+                            if CONF_DEVICETRACKER_ID in self.config_entry.data
+                            else None
+                        ),
                     ): selector.EntitySelector(
                         selector.SingleEntitySelectorConfig(domain=TRACKING_DOMAIN)
                     ),
                     vol.Optional(
-                        CONF_API_KEY, default=(self.config_entry.data[CONF_API_KEY] if CONF_API_KEY in self.config_entry.data else None)
+                        CONF_API_KEY,
+                        default=(
+                            self.config_entry.data[CONF_API_KEY]
+                            if CONF_API_KEY in self.config_entry.data
+                            else None
+                        ),
                     ): str,
                     vol.Optional(
-                        CONF_OPTIONS, default=(self.config_entry.data[CONF_OPTIONS] if CONF_OPTIONS in self.config_entry.data else None)
+                        CONF_OPTIONS,
+                        default=(
+                            self.config_entry.data[CONF_OPTIONS]
+                            if CONF_OPTIONS in self.config_entry.data
+                            else None
+                        ),
                     ): selector.SelectSelector(
                         selector.SelectSelectorConfig(
                             options=STATE_OPTIONS,
@@ -201,13 +215,22 @@ class PlacesOptionsFlowHandler(config_entries.OptionsFlow):
                         )
                     ),
                     vol.Optional(
-                        CONF_HOME_ZONE, default=(self.config_entry.data[CONF_HOME_ZONE] if CONF_HOME_ZONE in self.config_entry.data else None)
+                        CONF_HOME_ZONE,
+                        default=(
+                            self.config_entry.data[CONF_HOME_ZONE]
+                            if CONF_HOME_ZONE in self.config_entry.data
+                            else None
+                        ),
                     ): selector.EntitySelector(
                         selector.SingleEntitySelectorConfig(domain=HOME_LOCATION_DOMAIN)
                     ),
                     vol.Optional(
                         CONF_MAP_PROVIDER,
-                        default=(self.config_entry.data[CONF_MAP_PROVIDER] if CONF_MAP_PROVIDER in self.config_entry.data else None)
+                        default=(
+                            self.config_entry.data[CONF_MAP_PROVIDER]
+                            if CONF_MAP_PROVIDER in self.config_entry.data
+                            else None
+                        ),
                     ): selector.SelectSelector(
                         selector.SelectSelectorConfig(
                             options=MAP_PROVIDER_OPTIONS,
@@ -217,7 +240,12 @@ class PlacesOptionsFlowHandler(config_entries.OptionsFlow):
                         )
                     ),
                     vol.Optional(
-                        CONF_MAP_ZOOM, default=(self.config_entry.data[CONF_MAP_ZOOM] if CONF_MAP_ZOOM in self.config_entry.data else None)
+                        CONF_MAP_ZOOM,
+                        default=(
+                            self.config_entry.data[CONF_MAP_ZOOM]
+                            if CONF_MAP_ZOOM in self.config_entry.data
+                            else None
+                        ),
                     ): selector.NumberSelector(
                         selector.NumberSelectorConfig(
                             min=MAP_ZOOM_MIN,
@@ -226,11 +254,20 @@ class PlacesOptionsFlowHandler(config_entries.OptionsFlow):
                         )
                     ),
                     vol.Optional(
-                        CONF_LANGUAGE, default=(self.config_entry.data[CONF_LANGUAGE] if CONF_LANGUAGE in self.config_entry.data else None)
+                        CONF_LANGUAGE,
+                        default=(
+                            self.config_entry.data[CONF_LANGUAGE]
+                            if CONF_LANGUAGE in self.config_entry.data
+                            else None
+                        ),
                     ): str,
                     vol.Optional(
                         CONF_EXTENDED_ATTR,
-                        default=(self.config_entry.data[CONF_EXTENDED_ATTR] if CONF_EXTENDED_ATTR in self.config_entry.data else None)
+                        default=(
+                            self.config_entry.data[CONF_EXTENDED_ATTR]
+                            if CONF_EXTENDED_ATTR in self.config_entry.data
+                            else None
+                        ),
                     ): selector.BooleanSelector(selector.BooleanSelectorConfig()),
                 }
             ),

--- a/custom_components/places/sensor.py
+++ b/custom_components/places/sensor.py
@@ -38,7 +38,8 @@ from homeassistant.const import EVENT_HOMEASSISTANT_START
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.event import async_call_later
-from homeassistant.helpers.event import async_track_state_change, async_track_state_change_event
+from homeassistant.helpers.event import async_track_state_change
+from homeassistant.helpers.event import async_track_state_change_event
 from homeassistant.helpers.issue_registry import IssueSeverity
 from homeassistant.helpers.issue_registry import async_create_issue
 from homeassistant.helpers.typing import ConfigType
@@ -180,7 +181,11 @@ async def async_setup_platform(
     # _LOGGER.debug("[async_setup_platform] final import_config: " + str(import_config))
 
     all_yaml_hashes = []
-    if DOMAIN in hass.data and hass.data[DOMAIN] is not None and hass.data[DOMAIN].values() is not None:
+    if (
+        DOMAIN in hass.data
+        and hass.data[DOMAIN] is not None
+        and hass.data[DOMAIN].values() is not None
+    ):
         for m in list(hass.data[DOMAIN].values()):
             if CONF_YAML_HASH in m:
                 all_yaml_hashes.append(m[CONF_YAML_HASH])
@@ -307,13 +312,13 @@ class Places(Entity):
             + self._devicetracker_id
         )
 
-        #async_track_state_change(
+        # async_track_state_change(
         #    hass,
         #    self._devicetracker_id,
         #    self.tsc_update,
         #    from_state=None,
         #    to_state=None,
-        #)
+        # )
         async_track_state_change_event(
             hass,
             self._devicetracker_id,
@@ -455,7 +460,8 @@ class Places(Entity):
             return True
         else:
             return False
-    #def tsc_update(self, tscarg2, tsarg3, tsarg4):
+
+    # def tsc_update(self, tscarg2, tsarg3, tsarg4):
     def tsc_update(self, tscarg=None):
         """Call the do_update function based on the TSC (track state change) event"""
         if self.is_devicetracker_set():


### PR DESCRIPTION
There appear to be some python formatting errors in 2e1b21e316fab1a1e8e964a11a4a1818c4cdf729. This pull request
uses the [Black Code Formatter](https://github.com/psf/black) and [isort](https://pycqa.github.io/isort) to fix these issues.