### PR TITLE
Format Python code with isort & Black Code Formatter

### DIFF
--- a/custom_components/places/sensor.py
+++ b/custom_components/places/sensor.py
@@ -37,8 +37,9 @@ from homeassistant.const import CONF_SCAN_INTERVAL
 from homeassistant.const import EVENT_HOMEASSISTANT_START
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+# from homeassistant.helpers.event import async_track_state_change
 from homeassistant.helpers.event import async_call_later
-#from homeassistant.helpers.event import async_track_state_change
 from homeassistant.helpers.event import async_track_state_change_event
 from homeassistant.helpers.issue_registry import IssueSeverity
 from homeassistant.helpers.issue_registry import async_create_issue


### PR DESCRIPTION
There appear to be some python formatting errors in a201b8090ee7dee7dea17d7789057b0439ff2b75. This pull request
uses the [Black Code Formatter](https://github.com/psf/black) and [isort](https://pycqa.github.io/isort) to fix these issues.