### PR TITLE
Format Python code with isort & Black Code Formatter

### DIFF
--- a/custom_components/places/sensor.py
+++ b/custom_components/places/sensor.py
@@ -195,8 +195,7 @@ async def async_setup_platform(
     # _LOGGER.debug("[async_setup_platform] All yaml hashes: " + str(all_yaml_hashes))
     if import_config[CONF_YAML_HASH] not in all_yaml_hashes:
         _LOGGER.warning(
-            "New YAML sensor, importing: "
-            + str(import_config.get(CONF_NAME))
+            "New YAML sensor, importing: " + str(import_config.get(CONF_NAME))
         )
         hass.bus.async_listen_once(EVENT_HOMEASSISTANT_START, schedule_import)
     else:


### PR DESCRIPTION
There appear to be some python formatting errors in 978f76ecf254cf64ad31d3425a82abe21778544b. This pull request
uses the [Black Code Formatter](https://github.com/psf/black) and [isort](https://pycqa.github.io/isort) to fix these issues.