### PR TITLE
Format Python code with isort & Black Code Formatter

### DIFF
--- a/custom_components/places/config_flow.py
+++ b/custom_components/places/config_flow.py
@@ -32,7 +32,9 @@ MAP_PROVIDER_OPTIONS = ["apple", "google", "osm"]
 STATE_OPTIONS = ["zone, place", "formatted_place", "zone_name, place"]
 MAP_ZOOM_MIN = 1
 MAP_ZOOM_MAX = 20
-COMPONENT_CONFIG_URL = "https://github.com/custom-components/places#configuration-options"
+COMPONENT_CONFIG_URL = (
+    "https://github.com/custom-components/places#configuration-options"
+)
 
 # Note the input displayed to the user will be translated. See the
 # translations/<lang>.json file and strings.json. See here for further information:

--- a/custom_components/places/sensor.py
+++ b/custom_components/places/sensor.py
@@ -605,13 +605,19 @@ class Places(Entity):
             old_latitude = str(self._latitude)
         if self.is_float(self._longitude):
             old_longitude = str(self._longitude)
-        if self.is_float(self._hass.states.get(self._devicetracker_id).attributes.get("latitude")):
+        if self.is_float(
+            self._hass.states.get(self._devicetracker_id).attributes.get("latitude")
+        ):
             new_latitude = str(
                 self._hass.states.get(self._devicetracker_id).attributes.get("latitude")
             )
-        if self.is_float(self._hass.states.get(self._devicetracker_id).attributes.get("longitude")):
+        if self.is_float(
+            self._hass.states.get(self._devicetracker_id).attributes.get("longitude")
+        ):
             new_longitude = str(
-                self._hass.states.get(self._devicetracker_id).attributes.get("longitude")
+                self._hass.states.get(self._devicetracker_id).attributes.get(
+                    "longitude"
+                )
             )
         if self.is_float(self._home_latitude):
             home_latitude = str(self._home_latitude)


### PR DESCRIPTION
There appear to be some python formatting errors in 090a6e36bdafbeb4b6f847e4da25c723385923ca. This pull request
uses the [Black Code Formatter](https://github.com/psf/black) and [isort](https://pycqa.github.io/isort) to fix these issues.