### PR TITLE
Format Python code with isort & Black Code Formatter

### DIFF
--- a/custom_components/places/config_flow.py
+++ b/custom_components/places/config_flow.py
@@ -32,7 +32,9 @@ MAP_PROVIDER_OPTIONS = ["apple", "google", "osm"]
 STATE_OPTIONS = ["zone, place", "formatted_place", "zone_name, place"]
 MAP_ZOOM_MIN = 1
 MAP_ZOOM_MAX = 20
-COMPONENT_CONFIG_URL = "https://github.com/custom-components/places#configuration-options"
+COMPONENT_CONFIG_URL = (
+    "https://github.com/custom-components/places#configuration-options"
+)
 
 # Note the input displayed to the user will be translated. See the
 # translations/<lang>.json file and strings.json. See here for further information:


### PR DESCRIPTION
There appear to be some python formatting errors in a5965ed76af3d81acc497ecf4c275d88f5983cec. This pull request
uses the [Black Code Formatter](https://github.com/psf/black) and [isort](https://pycqa.github.io/isort) to fix these issues.