### PR TITLE
Format Python code with isort & Black Code Formatter

### DIFF
--- a/custom_components/places/sensor.py
+++ b/custom_components/places/sensor.py
@@ -609,13 +609,19 @@ class Places(Entity):
             old_latitude = str(self._latitude)
         if self.is_float(self._longitude):
             old_longitude = str(self._longitude)
-        if self.is_float(self._hass.states.get(self._devicetracker_id).attributes.get("latitude")):
+        if self.is_float(
+            self._hass.states.get(self._devicetracker_id).attributes.get("latitude")
+        ):
             new_latitude = str(
                 self._hass.states.get(self._devicetracker_id).attributes.get("latitude")
             )
-        if self.is_float(self._hass.states.get(self._devicetracker_id).attributes.get("longitude")):
+        if self.is_float(
+            self._hass.states.get(self._devicetracker_id).attributes.get("longitude")
+        ):
             new_longitude = str(
-                self._hass.states.get(self._devicetracker_id).attributes.get("longitude")
+                self._hass.states.get(self._devicetracker_id).attributes.get(
+                    "longitude"
+                )
             )
         if self.is_float(self._home_latitude):
             home_latitude = str(self._home_latitude)


### PR DESCRIPTION
There appear to be some python formatting errors in 4af466a0633b1e9ee63bd171bfcd55b9a9b52ad1. This pull request
uses the [Black Code Formatter](https://github.com/psf/black) and [isort](https://pycqa.github.io/isort) to fix these issues.