### PR TITLE
Format Python code with isort & Black Code Formatter

### DIFF
--- a/custom_components/places/config_flow.py
+++ b/custom_components/places/config_flow.py
@@ -190,7 +190,13 @@ class PlacesOptionsFlowHandler(config_entries.OptionsFlow):
             # )
             for m in dict(self.config_entry.data).keys():
                 user_input.setdefault(m, self.config_entry.data[m])
-                _LOGGER.debug("[Options Update] user_input[" + m + "]: '" + str(user_input.get(m)) + "'")
+                _LOGGER.debug(
+                    "[Options Update] user_input["
+                    + m
+                    + "]: '"
+                    + str(user_input.get(m))
+                    + "'"
+                )
                 if user_input.get(m) == "":
                     user_input.pop(m)
             _LOGGER.debug("[Options Update] user_input: " + str(user_input))


### PR DESCRIPTION
There appear to be some python formatting errors in ebbc4a1c33100a5862604a2505ba5f0210827465. This pull request
uses the [Black Code Formatter](https://github.com/psf/black) and [isort](https://pycqa.github.io/isort) to fix these issues.