### PR TITLE
Format Python code with isort & Black Code Formatter

### DIFF
--- a/custom_components/places/config_flow.py
+++ b/custom_components/places/config_flow.py
@@ -190,11 +190,23 @@ class PlacesOptionsFlowHandler(config_entries.OptionsFlow):
             # )
             for m in dict(self.config_entry.data).keys():
                 user_input.setdefault(m, self.config_entry.data[m])
-                _LOGGER.debug("[Options Update] user_input[" + m + "]: '" + str(user_input.get(m)) + "'")
+                _LOGGER.debug(
+                    "[Options Update] user_input["
+                    + m
+                    + "]: '"
+                    + str(user_input.get(m))
+                    + "'"
+                )
                 if not user_input.get(m):
                     user_input.pop(m)
             for m in dict(user_input).keys():
-                _LOGGER.debug("[Options Update] user_input[" + m + "]: '" + str(user_input.get(m)) + "'")
+                _LOGGER.debug(
+                    "[Options Update] user_input["
+                    + m
+                    + "]: '"
+                    + str(user_input.get(m))
+                    + "'"
+                )
                 if not user_input.get(m):
                     user_input.pop(m)
             _LOGGER.debug("[Options Update] user_input: " + str(user_input))


### PR DESCRIPTION
There appear to be some python formatting errors in 91e796e6790c95ceac60f8d4c45dee5df2449f8f. This pull request
uses the [Black Code Formatter](https://github.com/psf/black) and [isort](https://pycqa.github.io/isort) to fix these issues.